### PR TITLE
feat: Implementa navegação do Card para Detalhes da Tag

### DIFF
--- a/Itema/ContentView.swift
+++ b/Itema/ContentView.swift
@@ -2,14 +2,13 @@ import SwiftUI
 
 struct ContentView: View {
     var body: some View {
-        // Usando o componente TagCard 
-        TagCard(tag: TagCardViewStockTag(imageName: "iconeDaTag", name: "Nome da Tag"))
-            .padding() // Espaçamento opcional
+        TagsView()
+            
     }
 }
 
 struct ContentView_Previews: PreviewProvider {
     static var previews: some View {
-        ContentView()
+        TagsView()
     }
 }

--- a/Itema/Model/TagCardViewStockTag.swift
+++ b/Itema/Model/TagCardViewStockTag.swift
@@ -17,7 +17,7 @@ struct TagCard: View {
     
     var body: some View {
         VStack {
-            Image(tag.imageName)
+            Image(systemName: tag.imageName)
                 .resizable()
                 .scaledToFit()
                 .frame(width: 60, height: 60)

--- a/Itema/views/TagItemsView.swift
+++ b/Itema/views/TagItemsView.swift
@@ -1,0 +1,24 @@
+//
+//  TagItemsView.swift
+//  Itema
+//
+//  Created by iredefbmac_18 on 09/12/25.
+//
+
+import SwiftUI
+
+struct TagItemsView: View {
+    let tag : TagCardViewStockTag
+    
+    var body: some View {
+        VStack{
+            Text("Detalhes de  \(tag.name)")
+            Text("Placeholder Temporário")
+                .foregroundColor(.gray)
+            
+        }
+        .navigationTitle(tag.name)
+    }
+}
+
+

--- a/Itema/views/TagsView.swift
+++ b/Itema/views/TagsView.swift
@@ -1,0 +1,39 @@
+//
+//  TagsView.swift
+//  Itema
+//
+//  Created by iredefbmac_18 on 09/12/25.
+//
+
+import SwiftUI
+
+struct TagsView: View {
+    let tags = [
+        TagCardViewStockTag(imageName: "keyboard", name: "Teclado"),
+        TagCardViewStockTag(imageName: "display", name: "Monitor")
+    ]
+    
+    var body: some View {
+        NavigationStack {
+            VStack {
+                ForEach(tags, id: \.name) {
+                    tag in
+                    NavigationLink{
+                        TagItemsView(tag: tag)
+                    } label: {
+                        TagCard(tag: tag)
+                    }
+                    
+                }
+                
+            }
+            .navigationTitle("Tags")
+            
+        }
+        
+    }
+        
+}
+
+
+


### PR DESCRIPTION

Descrição completa: 
- Adicionado NavigationLink no TagCard dentro da TagsView para permitir o toque.
- Passagem do objeto StockTag selecionado para a próxima tela.
- Criação da TagItemsView funcionando como placeholder temporário para a próxima etapa.
- Configuração do título da navegação para exibir dinamicamente o nome da tag selecionada (ex: "Teclado").

Porque foi necessário: Cumprir o requisito de permitir que o usuário acesse a tela correspondente à tag ao clicar no card, garantindo uma navegação suave no padrão iOS.

Como testar :
1 - Abra o app no Simulador.
2 - Toque em um card (ex: "Mouse").
3 - Verifique se a navegação ocorre suavemente para a próxima tela.
4 - Confirme se o título da nova tela é "Mouse" (ou o nome da tag escolhida).
5 - Verifique se aparece o texto de placeholder "Detalhes de Mouse".

Checklist:
- [x] Adicionar ação de toque no TagCardView.
- [x] Criar placeholder para TagItemsView.
- [x] Passar objeto StockTag para a tela seguinte.
- [x] Exibir nome da tag na barra de título.
- [x] Código compila.
- [x] Testes manuais básicos realizados.  

Assignees: @Lopesssz
Reviewers: @laisbastosbg  
Labels: feat, navigation

